### PR TITLE
Clippy warnings fixed

### DIFF
--- a/macros/src/terminus_insn/init_treemap.rs
+++ b/macros/src/terminus_insn/init_treemap.rs
@@ -127,7 +127,7 @@ macro_rules! init_treemap {
                 let code = decoder.code();
                 let mask = decoder.mask();
                 if let Some(v) = self.0.insert(Box::new(decoder)) {
-                    __terminus_insn_panic!(__terminus_insn_format!("inst {}(code = {:#x}; mask = {:#x}) is duplicated with inst {}(code = {:#x}; mask = {:#x})!", name, code, mask,v.name(), v.code(), v.mask()))
+                    __terminus_insn_panic!("inst {}(code = {:#x}; mask = {:#x}) is duplicated with inst {}(code = {:#x}; mask = {:#x})!", name, code, mask,v.name(), v.code(), v.mask())
                 }
             }
 

--- a/proc_macros/src/csr/csr_map.rs
+++ b/proc_macros/src/csr/csr_map.rs
@@ -54,7 +54,7 @@ struct CsrMap {
 
 impl CsrMap {
     fn same_name(&self, rhs: &Self) -> bool {
-        self.name.to_string() == rhs.name.to_string()
+        rhs.name == self.name
     }
 
     fn addr_value(&self) -> u64 {
@@ -140,7 +140,8 @@ impl<'a> Maps<'a> {
                     ));
                 }
             }
-            Ok(self.maps.push(csr_map))
+            self.maps.push(csr_map);
+            Ok(())
         }
     }
 
@@ -252,7 +253,7 @@ impl<'a> Maps<'a> {
                 #fields_access
                 pub fn new(xlen:usize)->#struct_name {
                     if xlen != 32 && xlen !=64 {
-                        panic!(format!("xlen only support 32 or 64, but get {}", xlen));
+                        panic!("xlen only support 32 or 64, but get {}", xlen);
                     }
                     #struct_name{
                     xlen,

--- a/proc_macros/src/csr/define_csr.rs
+++ b/proc_macros/src/csr/define_csr.rs
@@ -23,7 +23,7 @@ impl Parse for Csr {
         let content: ParseBuffer;
         braced!(content in input);
         Ok(Csr {
-            name: name,
+            name,
             attrs: content.parse_terminated(CsrAttr::parse)?,
         })
     }
@@ -94,7 +94,7 @@ impl Field {
     }
 
     fn same_name(&self, rhs: &Self) -> bool {
-        self.name.to_string() == rhs.name.to_string()
+        rhs.name == self.name
     }
 
     fn overlap(&self, rhs: &Self) -> bool {
@@ -156,7 +156,7 @@ impl<'a> Fields<'a> {
     fn new(name: Ident, size: usize) -> Self {
         Fields {
             name,
-            size: size,
+            size,
             fields: vec![],
         }
     }
@@ -197,7 +197,8 @@ impl<'a> Fields<'a> {
                     ));
                 }
             }
-            Ok(self.fields.push(field))
+            self.fields.push(field);
+            Ok(())
         }
     }
 

--- a/proc_macros/src/insn.rs
+++ b/proc_macros/src/insn.rs
@@ -79,8 +79,8 @@ pub fn expand(ast: &DeriveInput, name: &Ident) -> Result<proc_macro2::TokenStrea
 fn check_fields(data: &DataStruct, name: &Ident) -> Result<()> {
     let msg = format!("expect \'struct {}();\' !", name.to_string());
     if let syn::Fields::Unnamed(ref field) = data.fields {
-        if field.unnamed.len() != 0 {
-            return Err(Error::new(field.paren_token.span, msg));
+        if !field.unnamed.is_empty() {
+            Err(Error::new(field.paren_token.span, msg))
         } else {
             Ok(())
         }
@@ -128,10 +128,10 @@ fn parse_raw_bits(lit: &LitStr) -> Result<String> {
             Ok(bits.to_string())
         }
     } else {
-        return Err(Error::new(
+        Err(Error::new(
             lit.span(),
             "code contains invalid char, valid format is ^[0-9]+b[1|0|?|_]+!",
-        ));
+        ))
     }
 }
 


### PR DESCRIPTION
Don't create strings just for comparison.
Use cannonical form for OK(()).
Remove unneeded format!() in panic!() call.
Use shortened structure initialization when variable is the same
name as the field in the struct.
Remove unneeded return statements.
Use is_empty() instead of comparison to 0.

I did test this and the spaceport fixes, and Linux still ran fine.